### PR TITLE
v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "toolbox",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"type": "commonjs",
 	"scripts": {
 		"ng": "ng",

--- a/projects/toolbox-main/src/app/common/elements/activity-monitor/activity-monitor.component.scss
+++ b/projects/toolbox-main/src/app/common/elements/activity-monitor/activity-monitor.component.scss
@@ -7,7 +7,7 @@
 
 :host,
 .container {
-	z-index: 1;
+	z-index: 2;
 	position: fixed;
 	top: 0;
 	left: 0;

--- a/projects/toolbox-main/src/app/common/elements/error-handler/error-handler.component.scss
+++ b/projects/toolbox-main/src/app/common/elements/error-handler/error-handler.component.scss
@@ -5,7 +5,7 @@
 	will-change: transform;
 	overflow-x: hidden;
 	overflow-y: auto;
-	z-index: 1;
+	z-index: 2;
 	position: fixed;
 	top: 0;
 	left: 0;

--- a/projects/toolbox-main/src/app/loot-table-randomizer/workers/loot-table-randomizer/loot-table-randomizer.worker.ts
+++ b/projects/toolbox-main/src/app/loot-table-randomizer/workers/loot-table-randomizer/loot-table-randomizer.worker.ts
@@ -4,13 +4,13 @@ import { LootTableFile } from "../../../../lib/ts-datapack-extensions/loot_table
 import "../../../../lib/ts-datapack-extensions/loot_table_file_ex";
 import { DatapackSerializer } from "../../../../lib/ts-datapack-fflate/datapack-serializer";
 import { Datapack } from "../../../../lib/ts-datapack/datapack";
+import { PackFormat } from "../../../../lib/ts-datapack/enums/packformat";
 import { GenericAdvancement } from "../../../../lib/ts-datapack/generic-advancement";
 import { GenericFile } from "../../../../lib/ts-datapack/genericfile";
 import { IFolder } from "../../../../lib/ts-datapack/interfaces/folder";
 import { IPredicate_EntityProperties } from "../../../../lib/ts-datapack/interfaces/predicate";
 import { Pack_MCMeta } from "../../../../lib/ts-datapack/pack_mcmeta";
 import { addMainDatapackAdvancement, filenameWithoutExtension, seededRandom, shuffle } from "../../../../lib/utils";
-import { PackFormat } from "../../../../lib/ts-datapack/enums/packformat";
 
 export class LootTableRandomizerWorker {
 	private _defaultLootTableFilePaths!: string[];
@@ -76,6 +76,13 @@ export class LootTableRandomizerWorker {
 		uz.register(UnzipInflate);
 
 		const reader: ReadableStreamDefaultReader<Uint8Array> = blob.stream().getReader();
+
+		// Firefox locks up, when trying to read the last bit of data of v1.20.0
+		// It seems, causing a bit of delay prevents the lock-up, outputting the reader instance in the console seems to do the trick.
+		// The only corresponding bug i could find has been resolved as "WORKSFORME" :/
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1646204
+		console.log(reader);
+
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) {

--- a/projects/toolbox-main/src/resources/data/changelog.json
+++ b/projects/toolbox-main/src/resources/data/changelog.json
@@ -133,5 +133,18 @@
 			"removals": []
 		},
 		"notes": ""
+	},
+	{
+		"version": "",
+		"build_date": "",
+		"changes": {
+			"additions": [],
+			"modifications": [
+				"Small style fixes for the new tool menu",
+				"Fixed a deadlock when using the v1.20.0 Loot-Table randomizer in Firefox"
+			],
+			"removals": []
+		},
+		"notes": ""
 	}
 ]

--- a/projects/toolbox-main/src/resources/data/changelog.json
+++ b/projects/toolbox-main/src/resources/data/changelog.json
@@ -135,8 +135,8 @@
 		"notes": ""
 	},
 	{
-		"version": "",
-		"build_date": "",
+		"version": "1.3.2",
+		"build_date": "2023-08-06",
 		"changes": {
 			"additions": [],
 			"modifications": [


### PR DESCRIPTION
* The tool menu arrows don't overlap the loading- and error indicators anymore
* Fixed a deadlock in the Loot-Table randomizer for v1.20.0 in Firefox (resolves #47)